### PR TITLE
fix standalone-test:

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ pip_install()
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/graknlabs/rules_nodejs.git",
-    commit = "ac3f6854365f119130186f971588514ccff503ab",
+    commit = "3d14bf46e177862fc14ea8de8ad5116924c5064e",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install")
@@ -133,7 +133,7 @@ rules_nodejs_dependencies()
 # ----- client nodejs + transitive dependencies -----
 git_repository(
     name = "graknlabs_client_nodejs",
-    remote = "https://github.com/graknlabs/grakn-client-nodejs",
+    remote = "https://github.com/graknlabs/client-nodejs",
     commit = 'af9a565b2ab828b856340d3e63490f74aed37341' # grakn-client-nodejs-dependency: do not remove this comment. this is used by the auto-update script
 )
 

--- a/test/standalone/nodejs/BUILD
+++ b/test/standalone/nodejs/BUILD
@@ -12,7 +12,8 @@ nodejs_jest_test(
         "@graknlabs_client_nodejs//:client-nodejs",
         "@nodejs_dependencies//jest",
         "@nodejs_dependencies//fs-extra"
-    ]
+    ],
+    tests_root = "generated"
 )
 
 genrule(
@@ -39,6 +40,6 @@ genrule(
 genrule(
     name = "move-test-standalone-nodejs-phone-calls",
     srcs = ["phoneCalls.js"],
-    cmd = "cp $(location phoneCalls.js) $(location generated/testStandalonePhoneCalls.js)",
-    outs = ["generated/testStandalonePhoneCalls.js"]
+    cmd = "cp $(location phoneCalls.js) $(location generated/testStandalonePhoneCalls.test.js)",
+    outs = ["generated/testStandalonePhoneCalls.test.js"]
 )


### PR DESCRIPTION
- use updated @bazelbuild_rules_nodejs which now support tests_root
- fix link to @graknlabs_client_nodejs
- use correct suffix (.test.js) so tests could be discovered by Jest