### PR TITLE
Fix not being able to import client-nodejs

### DIFF
--- a/test/standalone/nodejs/BUILD
+++ b/test/standalone/nodejs/BUILD
@@ -11,7 +11,11 @@ nodejs_jest_test(
     deps = [
         "@graknlabs_client_nodejs//:client-nodejs",
         "@nodejs_dependencies//jest",
-        "@nodejs_dependencies//fs-extra"
+        "@nodejs_dependencies//fs-extra",
+        "@nodejs_dependencies//:node_modules"
+    ],
+    data = [
+        "@graknlabs_client_nodejs//:package.json",
     ],
     tests_root = "generated"
 )

--- a/test/standalone/nodejs/phoneCalls.js
+++ b/test/standalone/nodejs/phoneCalls.js
@@ -1,9 +1,21 @@
-const Grakn = require("grakn");
-const fs = require("fs");
+const fs = require('fs-extra')
+fs.copySync(
+    '../../../external/graknlabs_client_nodejs/',
+    '../../../external/graknlabs_client_nodejs_nosymlinks/', {
+        dereference: true,
+        filter: (src, dest) => {
+            if (src.includes('client-nodejs') && !src.includes('client-nodejs-proto')) {
+                return false;
+            }
+            return true;
+        }
+    });
 
-const PhoneCallsCSVMigration = require("PhoneCallsCSVMigration.js");
-const PhoneCallsJSONMigration = require("PhoneCallsJSONMigration.js");
-const PhoneCallsXMLMigration = require("PhoneCallsXMLMigration.js");
+const Grakn = require('../../../../external/graknlabs_client_nodejs_nosymlinks/');
+
+const PhoneCallsCSVMigration = require("./PhoneCallsCSVMigration.js");
+const PhoneCallsJSONMigration = require("./PhoneCallsJSONMigration.js");
+const PhoneCallsXMLMigration = require("./PhoneCallsXMLMigration.js");
 
 beforeAll(async () => {
     await loadSchemaPhoneCalls();


### PR DESCRIPTION
* `"@nodejs_dependencies//:node_modules"` is added so `grpc` and other `client-nodejs`'s deps can be resolved
* `"@graknlabs_client_nodejs//:package.json"` is added so `client-nodejs` is a correct importable `node` package
* test module is at `$SANDBOX/docs/test/standalone/nodejs/jest/phoneCallsCSVMigration.js`
`client-nodejs` is at `$SANDBOX/external/graknlabs_client_nodejs` (consists of `src`, `client-nodejs-proto`, `package.json`, `client-nodejs` [we don't need this one])
* we copy `../../../external/graknlabs_client_nodejs/` to `../../../external/graknlabs_client_nodejs_nosymlinks/` so that it's a package containing `src`/`package.json`/`client-nodejs-proto` all as regular file
* `./PhoneCallsCSVMigration.js` and other tests should be imported from relative paths
on `../../../../external/graknlabs_client_nodejs_nosymlinks` (four `..` components) in `require` vs `../../..` (three `..` components`) in `fs.copySync`:

when running the test, current directory is `$SANDBOX/docs/test/standalone/nodejs/jest/` but `require` resolves it relative to the file in the dir which requires one more going level up